### PR TITLE
Adding "in" and "out" options to @Lazy

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Call this function as soon as the element is inside the viewport.
  * @param hostProperty Optionally provide the name of the `@Element()` property. Alternatively add `@LazyHost()`.
- * @param margin Optionally provide the padding (rootMargin) for IntersectionObserver. Determines how far from the viewport lazy loading starts. Can have values similar to the CSS margin property, e.g. "10px 20px 30px 40px" (top, right, bottom, left). The values can be percentages 
+ * @param margin Optionally provide the padding (rootMargin) for IntersectionObserver. Determines how far from the viewport lazy loading starts. Can have values similar to the CSS margin property, e.g. "10px 20px 30px 40px" (top, right, bottom, left). The values can be percentages
  * @example
 ```
 @LazyHost() @Element() host;
@@ -45,6 +45,11 @@ export function Lazy(options?: LazyOptions) {
       options.margin = proto["__lazyMargin"];
     }
 
+
+    if (proto["__lazyVisibility"]) {
+      options.visibility = proto["__lazyVisibility"];
+    }
+
     const { componentDidLoad } = proto;
     proto.componentDidLoad = function() {
       if ("IntersectionObserver" in window) {
@@ -56,10 +61,20 @@ export function Lazy(options?: LazyOptions) {
         }
         let io = new IntersectionObserver(
           (data: any) => {
-            if (data[0].isIntersecting) {
-              this[prop].apply(this);
-              io.disconnect();
-              io = null;
+            if (!options.visibility) {
+              if (data[0].isIntersecting) {
+                this[prop].apply(this);
+                io.disconnect();
+                io = null;
+              }
+            } else if (options.visibility === "in") {
+              if (data[0].isIntersecting) {
+                this[prop].apply(this);
+              }
+            } else if (options.visibility === "out") {
+              if (!data[0].isIntersecting) {
+                this[prop].apply(this);
+              }
             }
           },
           { rootMargin: margin }
@@ -106,4 +121,5 @@ export function getValidMargin(margin): string {
 export interface LazyOptions {
   hostProperty?: string;
   margin?: string;
+  visibility?: "in"|"out";
 }


### PR DESCRIPTION
Under some conditions, I want to clean up data or stop an animation or video when an element isn't in the viewport. this PR updates the `@Lazy` decorator to support "in" and "out" of viewport. 

You could use this by applying the `@Lazy` decorator to two methods:

```ts
import { Component, Prop, State, Element, h } from '@stencil/core';
import { Lazy, LazyHost } from 'st-lazy';

@Component({
  tag: 'animation-tag'
})
export class Animation {
  @LazyHost() @Element() element: HTMLElement;

  @Lazy({visibility: "in"})
  in() {
    this.prepare()
  }

  @Lazy({visibility: "out"})
  out() {
    this.destroy()
  }

  prepare() { /* ... */ }

  destroy() { /* ... */ }

  render() { /* ... */ }
}
```

A couple notes: 
- I think this may be applying two intersection observers, since I'm new to decorators. 
- Totally happy to change the naming of `visibility`, it's what I've been using internally and I don't have anyone to bikeshed with.  